### PR TITLE
Change the VM name to match the screenshot

### DIFF
--- a/labs/lab7/lab7.md
+++ b/labs/lab7/lab7.md
@@ -27,7 +27,7 @@ Click the `Create Virtual Machine` drop-down and select `Create with Wizard`
 
 In the `Basic Settings` configure with the following
 
-* Name: `vm3`
+* Name: `test`
 * Namespace: `myproject`
 * Provision Source: `Container`
 * Container Image: `docker.io/kubevirt/cirros-container-disk-demo:latest`
@@ -47,7 +47,7 @@ To start the virtual machine click the cog and select `Start Virtual Machine`.
 
 ![start vm](images/start_vm.png)
 
-Now click the virtual machine link `vm3`
+Now click the virtual machine link `test`
 
 ### Virtual Machine Overview and Console
 


### PR DESCRIPTION
This is a follow up of an old PR in the repo, #84.

It's the same change, but after the recent labs revamp it belongs to a different file.

Also there were 2 instances of the VM name to change, and this covers both.