### PR TITLE
Bug: Fixing link pointing to a bad URL

### DIFF
--- a/labs/lab001/lab001.md
+++ b/labs/lab001/lab001.md
@@ -19,7 +19,7 @@ All the boxes have been provisioned with an SSH public key, so you can SSH into 
 ```shell
 ## LAB 001
 
-wget https://raw.githubusercontent.com/kubevirt/kubevirt-tutorial/master/labs/lab1/RSA/kubevirt-tutorial
+wget https://raw.githubusercontent.com/kubevirt/kubevirt-tutorial/master/labs/lab001/RSA/kubevirt-tutorial
 chmod 600 kubevirt-tutorial
 ```
 


### PR DESCRIPTION
Detected error on kubevirt-Tutorial tests

- Fixing link for Lab001 and the URL for RSA file